### PR TITLE
Allowing empty pages to be rendered

### DIFF
--- a/core/diamondapp.d
+++ b/core/diamondapp.d
@@ -271,6 +271,10 @@ static if (isWeb)
         {
           response.bodyWriter.write(pageResult);
         }
+        else
+        {
+          response.bodyWriter.write("\n");
+        }
       }
       else
       {


### PR DESCRIPTION
Empty generated pages would trigger an error, which shouldn't happen.