### PR TITLE
Added build-in unittesting

### DIFF
--- a/controllers/basecontroller.d
+++ b/controllers/basecontroller.d
@@ -269,5 +269,16 @@ static if (isWeb)
 
       return value.hasValue ? value.get!T : defaultValue;
     }
+
+    static if (isTesting)
+    {
+      @property
+      {
+        import diamond.unittesting;
+
+        /// Gets a boolean determnining whether the request is a test or not.
+        bool testing() { return !testsPassed; }
+      }
+    }
   }
 }

--- a/core/apptype.d
+++ b/core/apptype.d
@@ -31,4 +31,15 @@ public
 
   /// Boolean determining whether the application is web related or not.
   static const bool isWeb = isWebServer || isWebApi;
+
+  version (Diamond_UnitTesting)
+  {
+    /// Boolean determining whether the application is running tests or not.
+    static const bool isTesting = true;
+  }
+  else
+  {
+    /// Boolean determining whether the application is running tests or not.
+    static const bool isTesting = false;
+  }
 }

--- a/http/client.d
+++ b/http/client.d
@@ -206,6 +206,33 @@ static if (isWeb)
       }
     }
 
+    /// Gets a model from the request's json.
+    T getModelFromJson(T, CTORARGS...)(CTORARGS args)
+    {
+      import vibe.data.json;
+
+      static if (is(T == struct))
+      {
+        T value;
+
+        value.deserializeJson(_request.json);
+
+        return value;
+      }
+      else static if (is(T == class))
+      {
+        auto value = new T(args);
+
+        value.deserializeJson(_request.json);
+
+        return value;
+      }
+      else
+      {
+        static assert(0);
+      }
+    }
+
     /**
     * Adds a generic context value to the client.
     * Params:
@@ -225,7 +252,7 @@ static if (isWeb)
     * Returns:
     *   The value if found, defaultValue otherwise.
     */
-    T getContext(T)(string name, T defaultValue = T.init)
+    T getContext(T)(string name, lazy T defaultValue = T.init)
     {
       import std.variant : Variant;
       Variant value = _request.context.get(name, Variant.init);

--- a/http/sessions.d
+++ b/http/sessions.d
@@ -93,7 +93,7 @@ static if (isWeb)
     * Returns:
     *   Returns the value retrieved or defaultValue if not found.
     */
-    T getValue(T = string)(string name, T defaultValue = T.init)
+    T getValue(T = string)(string name, lazy T defaultValue = T.init)
     {
       Variant value = _session.values.get(name, Variant.init);
 
@@ -357,7 +357,7 @@ static if (isWeb)
     {
       if (retries)
       {
-        runTask((InternalHttpSession s, size_t r) { invalidateSession(s, r, true); }, session, retries--);
+        runTask((InternalHttpSession s, size_t r) { invalidateSession(s, r, true); }, session, retries - 1);
       }
     }
   }

--- a/unittesting/attributes.d
+++ b/unittesting/attributes.d
@@ -1,0 +1,18 @@
+/**
+* Copyright © DiamondMVC 2016-2017
+* License: MIT (https://github.com/DiamondMVC/Diamond/blob/master/LICENSE)
+* Author: Jacob Jensen (bausshf)
+*/
+module diamond.unittesting.attributes;
+
+import diamond.core.apptype;
+
+static if (isWeb && isTesting)
+{
+  /// Attribute to define a test.
+  struct HttpTest
+  {
+    /// The name of the test.
+    string name;
+  }
+}

--- a/unittesting/initialization.d
+++ b/unittesting/initialization.d
@@ -1,0 +1,156 @@
+/**
+* Copyright © DiamondMVC 2016-2017
+* License: MIT (https://github.com/DiamondMVC/Diamond/blob/master/LICENSE)
+* Author: Jacob Jensen (bausshf)
+*/
+module diamond.unittesting.initialization;
+
+import diamond.core.apptype;
+
+static if (isWeb && isTesting)
+{
+  /// Boolean determinng whether all tests has passed or not.
+  package(diamond) __gshared bool testsPassed;
+
+  /// Wrapper around a test's failure result.
+  private class TestFailResult
+  {
+    /// The name of the test.
+    string name;
+    /// The error.
+    string error;
+  }
+
+  /// Initializes the tests.
+  package(diamond) void initializeTests()
+  {
+    TestFailResult[] failedTests;
+
+    mixin HandleTests;
+    handleTests();
+
+    import diamond.core.io;
+
+    if (failedTests && failedTests.length)
+    {
+      import vibe.core.core : exitEventLoop;
+
+      exitEventLoop();
+
+      print("The following tests has failed:");
+
+      foreach (test; failedTests)
+      {
+        print("-------------------");
+        print("Test: %s", test.name);
+        print("Error:");
+        print(test.error);
+        print("-------------------");
+      }
+    }
+    else
+    {
+      testsPassed = true;
+      print("All tests has passed.");
+    }
+  }
+
+  /// Mixin template to handle the tests.
+  private mixin template HandleTests()
+  {
+    static string[] getModules()
+    {
+      import std.string : strip;
+      import std.array : replace, split;
+
+      string[] modules = [];
+
+      import diamond.core.io : handleCTFEFile;
+
+      mixin handleCTFEFile!("unittests.config", q{
+        auto lines = __fileResult.replace("\r", "").split("\n");
+
+        foreach (line; lines)
+        {
+          if (!line || !line.strip().length)
+          {
+            continue;
+          }
+
+          modules ~= line.strip();
+        }
+      });
+      handle();
+
+      return modules;
+    }
+
+    enum moduleNames = getModules();
+
+    static string generateTests()
+    {
+      string s = "";
+
+      foreach (moduleName; moduleNames)
+      {
+        s ~= "{ import " ~ moduleName ~ ";\r\n";
+        s ~= "foreach (member; __traits(allMembers, " ~ moduleName ~ "))\r\n";
+
+        s ~= q{
+        	{
+        		mixin(q{
+              static if (mixin("hasUDA!(%1$s, HttpTest)"))
+              {
+                static test_%1$s = getUDAs!(%1$s, HttpTest)[0];
+
+                auto testName =
+                  test_%1$s.name && test_%1$s.name.length ? test_%1$s.name : "%1$s";
+
+                try
+                {
+                  static if (is(ReturnType!%1$s == bool))
+                  {
+                    if (!%1$s())
+                    {
+                      auto testFailResult = new TestFailResult;
+                      testFailResult.name = testName;
+                      testFailResult.error = "Returned false.";
+
+                      failedTests ~= testFailResult;
+                    }
+                  }
+                  else
+                  {
+                    %1$s();
+                  }
+                }
+                catch (Throwable t)
+                {
+                  auto testFailResult = new TestFailResult;
+                  testFailResult.name = testName;
+                  testFailResult.error = t.toString();
+
+                  failedTests ~= testFailResult;
+                }
+              }
+            }.format(member));
+        	}
+        };
+
+        s ~= "}\r\n";
+      }
+
+      return s;
+    }
+
+    void handleTests()
+    {
+      import std.string : format;
+      import std.traits : hasUDA, getUDAs, ReturnType;
+      import diamond.core.collections;
+      import diamond.unittesting.attributes;
+
+      mixin(generateTests());
+    }
+  }
+}

--- a/unittesting/package.d
+++ b/unittesting/package.d
@@ -1,0 +1,15 @@
+/**
+* Copyright © DiamondMVC 2016-2017
+* License: MIT (https://github.com/DiamondMVC/Diamond/blob/master/LICENSE)
+* Author: Jacob Jensen (bausshf)
+*/
+module diamond.unittesting;
+
+public
+{
+  import diamond.unittesting.initialization;
+  import diamond.unittesting.request;
+  import diamond.unittesting.attributes;
+
+  import diamond.core.apptype : isTesting;
+}

--- a/unittesting/request.d
+++ b/unittesting/request.d
@@ -1,0 +1,209 @@
+/**
+* Copyright © DiamondMVC 2016-2017
+* License: MIT (https://github.com/DiamondMVC/Diamond/blob/master/LICENSE)
+* Author: Jacob Jensen (bausshf)
+*/
+module diamond.unittesting.request;
+
+import diamond.core.apptype;
+
+static if (isWeb && isTesting)
+{
+  import std.conv : to;
+
+  import vibe.d : HTTPClientRequest, HTTPClientResponse, requestHTTP, HTTPMethod, Json;
+
+  public import diamond.http.method;
+  public import diamond.http.status;
+
+  /// Wrapper around a http unittet result.
+  final class HttpUnitTestResult
+  {
+    private:
+    /// The response.
+    HTTPClientResponse _response;
+
+    /// The body data.
+    string _bodyData;
+
+    /**
+    * Creates a new http unittest result.
+    * Params:
+    *   response = The response.
+    */
+    this(HTTPClientResponse response)
+    {
+      _response = response;
+    }
+
+    public:
+    final:
+    @property
+    {
+      /// Gets the raw vibe.d response.
+      HTTPClientResponse rawResponse() { return _response; }
+
+      /// Gets the raw vibe.d response stream.
+      auto responseStream() { return _response.bodyReader; }
+
+      /// Gets the status code.
+      HttpStatus statusCode() { return cast(HttpStatus)_response.statusCode; }
+
+      /// Gets the content type.
+      string contentType() { return _response.contentType; }
+
+      /// Gets the json.
+      auto json() { return _response.readJson(); }
+
+      /// Gets the body data.
+      auto bodyData()
+      {
+        import vibe.stream.operations : readAllUTF8;
+
+        if (!_bodyData)
+        {
+          _bodyData = _response.bodyReader.readAllUTF8();
+        }
+
+        return _bodyData;
+      }
+    }
+
+    /**
+    * Gets a cookie.
+    * Params:
+    *   name =         The name of the cookie.
+    *   defaultValue = The default value.
+    * Returns:
+    *   The value of the cookie if present, default value otherwise.
+    */
+    string getCookie(string name, lazy string defaultValue = null)
+    {
+      if (name !in _response.cookies)
+      {
+        return defaultValue;
+      }
+
+      return _response.cookies[name].value;
+    }
+
+    /**
+    * Checks whether a cookie is present or not.
+    * Params:
+    *   name = The name of the cookie.
+    * Returns:
+    *   True if the cookie is present, false otherwise.
+    */
+    bool hasCookie(string name)
+    {
+      return cast(bool)(name in _response.cookies);
+    }
+
+    /**
+    * Gets a header.
+    * Params:
+    *   name = The name of the header.
+    *   defaultValue = The default value.
+    * Returns:
+    *   The value if present, default value otherwise.
+    */
+    string getHeader(string name, lazy string defaultValue)
+    {
+      return _response.headers.get(name, defaultValue);
+    }
+
+    /**
+    * Checks whether a header is present or not.
+    * Params:
+    *   name = The name of the header.
+    * Returns:
+    *   True if the header is present, false otherwise.
+    */
+    bool hasHeader(string name)
+    {
+      return getHeader(name, null) !is null;
+    }
+
+    /// Gets a model from the response's json.
+    T getModelFromJson(T, CTORARGS...)(CTORARGS args)
+    {
+      import vibe.data.json;
+
+      static if (is(T == struct))
+      {
+        T value;
+
+        value.deserializeJson(json);
+
+        return value;
+      }
+      else static if (is(T == class))
+      {
+        auto value = new T(args);
+
+        value.deserializeJson(json);
+
+        return value;
+      }
+      else
+      {
+        static assert(0);
+      }
+    }
+  }
+
+  /**
+  * Creates an internal test request.
+  * Params:
+  *   route =     The route (not URL!) to call.
+  *   method =    The method to use for thr request.
+  *   responder = The handler for the unittest result.
+  *   requester = Custom handler for the raw vibe.d request. Can be used to setup the request data etc.
+  */
+  void testRequest
+  (
+    string route, HttpMethod method,
+    scope void delegate(scope HttpUnitTestResult) responder,
+    scope void delegate(scope HTTPClientRequest) requester = null,
+  )
+  {
+    import diamond.errors.checks;
+
+    enforce(responder !is null, "No responder defined.");
+
+    import diamond.core.webconfig;
+    auto address = webConfig.addresses[0];
+
+    if (route[0] != '/')
+    {
+      route = "/" ~ route;
+    }
+
+    auto ipAddress = address.ipAddresses[0];
+
+    if (ipAddress == "::1")
+    {
+      ipAddress = "127.0.0.1";
+    }
+
+    auto url = "http://" ~ ipAddress ~ ":" ~ to!string(address.port) ~ route;
+
+    requestHTTP
+    (
+      url,
+  		(scope request)
+      {
+  			request.method = cast(HTTPMethod)method;
+
+        if (requester !is null)
+        {
+          requester(request);
+        }
+  		},
+  		(scope response)
+      {
+  			responder(new HttpUnitTestResult(response));
+  		}
+  	);
+  }
+}

--- a/views/view.d
+++ b/views/view.d
@@ -69,7 +69,7 @@ static if (!isWebApi)
       this(HttpClient client, string name)
       {
         import diamond.errors.checks;
-        
+
         _client = enforceInput(client, "Cannot create a view without an associated client.");
         _name = name;
 
@@ -153,6 +153,14 @@ static if (!isWebApi)
           }
 
           return rootPathValue;
+        }
+
+        static if (isTesting)
+        {
+          import diamond.unittesting;
+
+          /// Gets a boolean determnining whether the request is a test or not.
+          bool testing() { return !testsPassed; }
         }
       }
 


### PR DESCRIPTION
Added build-in unittesting that can be used to create unittests  suited for http requests etc. Also added better json conversions to HttpClient which can convert directly to a model, avoiding direct use of vibe.d for json. Also added lazyness for default values.