### PR TITLE
Fixed session bug

### DIFF
--- a/http/client.d
+++ b/http/client.d
@@ -10,7 +10,7 @@ import diamond.core.apptype;
 static if (isWeb)
 {
   /// The name of the language session key.
-  private static const languageSessionKey = "__D_LANGUAGE";
+  private static __gshared const languageSessionKey = "__D_LANGUAGE";
 
   /// Wrapper around the client's request aand response.
   final class HttpClient
@@ -235,7 +235,7 @@ static if (isWeb)
       {
         if (_language is null)
         {
-          _language = _session.getValue(languageSessionKey, "");
+          _language = session.getValue!string(languageSessionKey, "");
         }
 
         return _language;
@@ -245,7 +245,7 @@ static if (isWeb)
       void language(string newLanguage)
       {
         _language = newLanguage;
-        _session.setValue(languageSessionKey, _language);
+        session.setValue(languageSessionKey, _language);
       }
     }
 

--- a/security/csrf.d
+++ b/security/csrf.d
@@ -24,7 +24,7 @@ static if (isWeb)
   */
   string generateCSRFToken(HttpClient client)
   {
-    auto token = client.session.getValue(CSRFTokenKey);
+    auto token = client.session.getValue!string(CSRFTokenKey);
 
     if (token)
     {
@@ -67,7 +67,7 @@ static if (isWeb)
   {
     enforce(token && token.length == 64, "Invalid csrf token.");
 
-    auto csrfToken = client.session.getValue(CSRFTokenKey);
+    auto csrfToken = client.session.getValue!string(CSRFTokenKey);
 
     if (csrfToken && removeToken)
     {


### PR DESCRIPTION
Sessions were used wrong internally in the HttpClient, which should use the property for getting the session and not the private member. This caused applications to hang when using i18n before the session had been set.