### PR TITLE
Changed placeHolder to placeholder

### DIFF
--- a/mail/smtp.d
+++ b/mail/smtp.d
@@ -13,7 +13,8 @@ static if (isWeb)
                   TLSContext, TLSPeerValidationMode, TLSVersion,
                   Mail, sendMail;
 
-  import diamond.errors.check;
+  import diamond.errors.checks;
+  import diamond.core.traits;
 
   // Alias to SMTPAuthType.
   mixin(createEnumAlias!SMTPAuthType("SmtpAuthType"));
@@ -66,21 +67,21 @@ static if (isWeb)
     @property
     {
       /// Gets the authentication type.
-      SmtpAuthType authType() { return _settings.authType; }
+      SmtpAuthType authType() { return cast(SmtpAuthType)_settings.authType; }
 
       /// Sets the authentication type.
       void authType(SmtpAuthType newAuthType)
       {
-        _settings = newAuthType;
+        _settings.authType = cast(SMTPAuthType)newAuthType;
       }
 
       /// Gets the connection type.
-      SmtpConnectionType connectionType() { return _settings.connectionType; }
+      SmtpConnectionType connectionType() { return cast(SmtpConnectionType)_settings.connectionType; }
 
       /// Sets the connection type.
       void connectionType(SmtpConnectionType newConnectionType)
       {
-        _settings.connectionType = newConnectionType;
+        _settings.connectionType = cast(SMTPConnectionType)newConnectionType;
       }
 
       /// Gets the host.
@@ -89,7 +90,7 @@ static if (isWeb)
       /// Sets the host.
       void host(string newHost)
       {
-        _settings = newHost;
+        _settings.host = newHost;
       }
 
       /// Gets the local name.
@@ -129,10 +130,10 @@ static if (isWeb)
       }
 
       /// Get the tls context setup.
-      @safe void delegate(scope TLSContext) tlsContextSetup() { return _settings.tlsContextSetup; }
+      void delegate(scope TLSContext) @safe tlsContextSetup() { return _settings.tlsContextSetup; }
 
       /// Sets the tls context setup.
-      void tlsContextSetup(@safe void delegate(scope TLSContext) newContextSetup)
+      void tlsContextSetup(void delegate(scope TLSContext) @safe newContextSetup)
       {
         _settings.tlsContextSetup = newContextSetup;
       }
@@ -167,6 +168,8 @@ static if (isWeb)
     SmtpClientSettings _settings;
     /// The sender.
     string _sender;
+    /// The from-mail.
+    string _fromMail;
     /// The recipient;
     string _recipient;
     /// The subject.

--- a/templates/contentmode.d
+++ b/templates/contentmode.d
@@ -11,7 +11,7 @@ enum ContentMode
   /// Will append content to the view.
   appendContent,
   /// Will append content to the view with a placeholder
-  appendContentPlaceHolder,
+  appendContentPlaceholder,
   /// Will mixin the content as D code.
   mixinContent,
   /// Will parse the content as meta and handle it as such

--- a/templates/parser.d
+++ b/templates/parser.d
@@ -26,8 +26,8 @@ private
     );
 
     grammars['<'] = new Grammar(
-      "placeHolder", '<', '>',
-      ContentMode.appendContentPlaceHolder, CharacterIncludeMode.none, false, false
+      "placeholder", '<', '>',
+      ContentMode.appendContentPlaceholder, CharacterIncludeMode.none, false, false
     );
 
     grammars['{'] = new Grammar(

--- a/views/view.d
+++ b/views/view.d
@@ -47,8 +47,8 @@ static if (!isWebApi)
     /// The name of the view.
     string _name;
 
-    /// The place holders.
-    string[string] _placeHolders;
+    /// The placeholders.
+    string[string] _placeholders;
 
     /// The result.
     string _result;
@@ -79,8 +79,8 @@ static if (!isWebApi)
         _client = enforceInput(client, "Cannot create a view without an associated client.");
         _name = name;
 
-        _placeHolders["doctype"] = "<!DOCTYPE html>";
-        _placeHolders["defaultRoute"] = _client.route.name;
+        _placeholders["doctype"] = "<!DOCTYPE html>";
+        _placeholders["defaultRoute"] = _client.route.name;
 
         import diamond.extensions;
         mixin ExtensionEmit!(ExtensionType.viewCtorExtension, q{
@@ -221,9 +221,32 @@ static if (!isWebApi)
       *   key =   The key of the place holder.
       *   value = The value of the place holder.
       */
-      void addPlaceHolder(string key, string value)
+      deprecated("Please use addPlaceholder() -- Will be removed in 2.9.0") void addPlaceHolder(string key, string value)
       {
-        _placeHolders[key] = value;
+        addPlaceholder(key, value);
+      }
+
+      /**
+      * Gets a place holder of the view.
+      * Params:
+      *   key =   The key of the place holder.
+      * Returns:
+      *   Returns the place holder.
+      */
+      deprecated("Please use getPlaceholder() -- Will be removed in 2.9.0") string getPlaceHolder(string key)
+      {
+        return getPlaceholder(key);
+      }
+
+      /**
+      * Adds a place holder to the view.
+      * Params:
+      *   key =   The key of the place holder.
+      *   value = The value of the place holder.
+      */
+      void addPlaceholder(string key, string value)
+      {
+        _placeholders[key] = value;
       }
 
       /**
@@ -235,7 +258,7 @@ static if (!isWebApi)
       */
       string getPlaceHolder(string key)
       {
-        return _placeHolders.get(key, null);
+        return _placeholders.get(key, null);
       }
 
       /**
@@ -256,11 +279,11 @@ static if (!isWebApi)
             layoutView.name = name;
             layoutView._renderView = this;
 
-            layoutView.addPlaceHolder("view", result);
+            layoutView.addPlaceholder("view", result);
 
-            foreach (key,value; _placeHolders)
+            foreach (key,value; _placeholders)
             {
-              layoutView.addPlaceHolder(key, value);
+              layoutView.addPlaceholder(key, value);
             }
 
             result = layoutView.generate();

--- a/views/viewformats.d
+++ b/views/viewformats.d
@@ -54,7 +54,7 @@ static if (!isWebApi)
             // controller
             %s
 
-            // placeHolders
+            // placeholders
             %s
 
             switch (sectionName)
@@ -142,7 +142,7 @@ static if (!isWebApi)
         {
           try
           {
-            // placeHolders
+            // placeholders
             %s
 
             switch (sectionName)
@@ -207,10 +207,10 @@ static if (!isWebApi)
   };
 
   /// The format for place holders.
-  enum placeHolderFormat = q{
+  enum placeholderFormat = q{
     foreach (key,value; %s)
     {
-      super.addPlaceHolder(key,value);
+      super.addPlaceholder(key,value);
     }
   };
 

--- a/views/viewparser.d
+++ b/views/viewparser.d
@@ -33,7 +33,7 @@ static if (!isWebApi)
     string viewConstructorGeneration = "";
     string viewModelGenerateGeneration = "";
     string viewCodeGeneration = "";
-    string viewPlaceHolderGeneration = "";
+    string viewPlaceholderGeneration = "";
     bool hasController;
     bool useBaseView;
     bool hasDefaultSection;
@@ -81,7 +81,7 @@ static if (!isWebApi)
             break;
           }
 
-          case ContentMode.appendContentPlaceHolder:
+          case ContentMode.appendContentPlaceholder:
           {
             viewCodeGeneration ~= parseAppendPlaceholderContent(part);
             break;
@@ -99,7 +99,7 @@ static if (!isWebApi)
               part,
               viewName,
               viewClassMembersGeneration, viewConstructorGeneration,
-              viewModelGenerateGeneration, viewPlaceHolderGeneration,
+              viewModelGenerateGeneration, viewPlaceholderGeneration,
               useBaseView,
               hasController,
               route
@@ -128,7 +128,7 @@ static if (!isWebApi)
         viewConstructorGeneration,
         viewModelGenerateGeneration,
         hasController ? controllerHandleFormat : "",
-        viewPlaceHolderGeneration,
+        viewPlaceholderGeneration,
         viewCodeGeneration,
         endFormat
       );
@@ -140,7 +140,7 @@ static if (!isWebApi)
         viewClassMembersGeneration,
         viewConstructorGeneration,
         viewModelGenerateGeneration,
-        viewPlaceHolderGeneration,
+        viewPlaceholderGeneration,
         viewCodeGeneration,
         endFormat
       );
@@ -157,7 +157,7 @@ static if (!isWebApi)
   */
   string parseAppendPlaceholderContent(Part part)
   {
-    return appendFormat.format("getPlaceHolder(`" ~ part.content ~ "`)");
+    return appendFormat.format("getPlaceholder(`" ~ part.content ~ "`)");
   }
 
   /**
@@ -210,7 +210,7 @@ static if (!isWebApi)
     ref string viewClassMembersGeneration,
     ref string viewConstructorGeneration,
     ref string viewModelGenerateGeneration,
-    ref string viewPlaceHolderGeneration,
+    ref string viewPlaceholderGeneration,
     ref bool useBaseView,
     ref bool hasController,
     ref string route)
@@ -240,9 +240,10 @@ static if (!isWebApi)
 
       switch (key)
       {
-        case "placeHolders":
+        case "placeHolders": // TODO: Remove in 2.9.0
+        case "placeholders":
         {
-          viewPlaceHolderGeneration = placeHolderFormat.format(value);
+          viewPlaceholderGeneration = placeholderFormat.format(value);
           break;
         }
 


### PR DESCRIPTION
"placeHolder" usage is now deprecated. In 2.9.0 all places using "placeHolder" will be removed. All places that uses "placeHolder" should be used with "placeholder" now. Example: "addPlaceHolder()" should be "addPlaceholder()"