### PR TITLE
Added i18n placeholder functionality

### DIFF
--- a/data/i18n/messages.d
+++ b/data/i18n/messages.d
@@ -9,7 +9,6 @@ import diamond.core.apptype;
 
 static if (isWeb)
 {
-
   import diamond.http;
 
   /// Alias for an associative array.
@@ -19,7 +18,7 @@ static if (isWeb)
   private __gshared Language[string] _messages;
 
   /// The default language.
-  private __gshared string _defaultLanguage;
+  package(diamond) __gshared string _defaultLanguage;
 
   /**
   * Sets the default language of the application.

--- a/http/client.d
+++ b/http/client.d
@@ -285,7 +285,9 @@ static if (isWeb)
       {
         if (_language is null)
         {
-          _language = session.getValue!string(languageSessionKey, "");
+          import diamond.data.i18n.messages : _defaultLanguage;
+          
+          _language = session.getValue!string(languageSessionKey, _defaultLanguage);
         }
 
         return _language;

--- a/views/view.d
+++ b/views/view.d
@@ -87,7 +87,10 @@ static if (!isWebApi)
           mixin {{extensionEntry}}.extension;
         });
 
-        onViewCtor();
+        static if (__traits(compiles, { onViewCtor();}))
+        {
+          onViewCtor();
+        }
       }
     }
     else

--- a/views/viewparser.d
+++ b/views/viewparser.d
@@ -83,7 +83,14 @@ static if (!isWebApi)
 
           case ContentMode.appendContentPlaceholder:
           {
-            viewCodeGeneration ~= parseAppendPlaceholderContent(part);
+            if (part.content[0] == '%' && part.content[$-1] == '%')
+            {
+              viewCodeGeneration ~= parseAppendTranslateContent(part);
+            }
+            else
+            {
+              viewCodeGeneration ~= parseAppendPlaceholderContent(part);
+            }
             break;
           }
 
@@ -158,6 +165,18 @@ static if (!isWebApi)
   string parseAppendPlaceholderContent(Part part)
   {
     return appendFormat.format("getPlaceholder(`" ~ part.content ~ "`)");
+  }
+
+  /**
+  * Parses content that can be appended as i18n.
+  * Params:
+  *   part = The part to parse.
+  * Returns:
+  *   The appended result.
+  */
+  string parseAppendTranslateContent(Part part)
+  {
+    return appendFormat.format("i18n.getMessage(super.client, \"" ~ part.content[1 .. $-1] ~ "\")");
   }
 
   /**


### PR DESCRIPTION
If a placeholder starts with % and ends with % then it'll be treated as a call to i18n.getMessage() instead of getPlaceholder()