### PR TITLE
Added @HttpNoAction attribute for controllers

### DIFF
--- a/controllers/attributes.d
+++ b/controllers/attributes.d
@@ -27,6 +27,9 @@ static if (isWeb)
     string action;
   }
 
+  /// Attribute for a no-action handler.
+  struct HttpNoAction {}
+
   /// Attribute for authentication.
   struct HttpAuthentication
   {

--- a/controllers/basecontroller.d
+++ b/controllers/basecontroller.d
@@ -147,6 +147,8 @@ static if (isWeb)
     Action _defaultAction;
     /// The mandatory action for the controller.
     Action _mandatoryAction;
+    /// The no-action handler for the controller.
+    Action _noAction;
 
     /// Creates a new base controller.
     this() { }
@@ -249,6 +251,36 @@ static if (isWeb)
     void mapMandatory(Status function() f)
     {
       _mandatoryAction = new Action(f);
+    }
+
+    /**
+    * Maps a no-action for the controller.
+    * Params:
+    *     fun =       The controller action associated with the mapping.
+    */
+    void mapNoAction(Action fun)
+    {
+      _noAction = fun;
+    }
+
+    /**
+    * Maps a no-action for the controller.
+    * Params:
+    *     d =       The controller action associated with the mapping.
+    */
+    void mapNoAction(Status delegate() d)
+    {
+      _noAction = new Action(d);
+    }
+
+    /**
+    * Maps a no-action for the controller.
+    * Params:
+    *     f =       The controller action associated with the mapping.
+    */
+    void mapNoAction(Status function() f)
+    {
+      _noAction = new Action(f);
     }
 
     /**

--- a/controllers/controller.d
+++ b/controllers/controller.d
@@ -51,6 +51,14 @@ static if (isWeb)
     }
   };
 
+  /// The format used for no-action formats.
+  enum noActionMappingFormat = q{
+    static if (hasUDA!(%1$s.%2$s, HttpNoAction))
+    {
+      mapNoAction(&controller.%2$s);
+    }
+  };
+
   /// The format for creating the http acton member.
   enum actionNameFormat = "static HttpAction action_%2$s;\r\n";
 
@@ -219,6 +227,7 @@ static if (isWebServer)
         {
           mixin(defaultMappingFormat.format(TController.stringof, member));
           mixin(mandatoryMappingFormat.format(TController.stringof, member));
+          mixin(noActionMappingFormat.format(TController.stringof, member));
           mixin(actionMappingFormat.format(TController.stringof, member));
           mixin(disableAuthFormat.format(TController.stringof, member));
           mixin(restrictedFormat.format(TController.stringof, member));
@@ -358,6 +367,13 @@ static if (isWebServer)
           return _defaultAction();
         }
 
+        if (_noAction)
+        {
+          auto noActionResult = _noAction();
+
+          return noActionResult;
+        }
+
         return Status.success;
       }
 
@@ -365,13 +381,27 @@ static if (isWebServer)
 
       if (!methodEntries)
       {
-          return Status.notFound;
+        if (_noAction)
+        {
+          auto noActionResult = _noAction();
+
+          return noActionResult;
+        }
+
+        return Status.notFound;
       }
 
       auto action = methodEntries.get(_view.route.action, null);
 
       if (!action)
       {
+        if (_noAction)
+        {
+          auto noActionResult = _noAction();
+
+          return noActionResult;
+        }
+
         return Status.notFound;
       }
 
@@ -489,6 +519,7 @@ else static if (isWebApi)
         {
           mixin(defaultMappingFormat.format(TController.stringof, member));
           mixin(mandatoryMappingFormat.format(TController.stringof, member));
+          mixin(noActionMappingFormat.format(TController.stringof, member));
           mixin(actionMappingFormat.format(TController.stringof, member));
           mixin(disableAuthFormat.format(TController.stringof, member));
           mixin(restrictedFormat.format(TController.stringof, member));
@@ -633,6 +664,13 @@ else static if (isWebApi)
           return _defaultAction();
         }
 
+        if (_noAction)
+        {
+          auto noActionResult = _noAction();
+
+          return noActionResult;
+        }
+
         return Status.notFound;
       }
 
@@ -640,6 +678,13 @@ else static if (isWebApi)
 
       if (!methodEntries)
       {
+        if (_noAction)
+        {
+          auto noActionResult = _noAction();
+
+          return noActionResult;
+        }
+
         return Status.notFound;
       }
 
@@ -647,6 +692,13 @@ else static if (isWebApi)
 
       if (!action)
       {
+        if (_noAction)
+        {
+          auto noActionResult = _noAction();
+
+          return noActionResult;
+        }
+
         return Status.notFound;
       }
 


### PR DESCRIPTION
The attribute can be used to handle cases where there are no actions given to the request. Useful for certain REST designs.