### PR TITLE
Change "init" to "app"

### DIFF
--- a/app/api.d
+++ b/app/api.d
@@ -3,7 +3,7 @@
 * License: MIT (https://github.com/DiamondMVC/Diamond/blob/master/LICENSE)
 * Author: Jacob Jensen (bausshf)
 */
-module diamond.init.api;
+module diamond.app.api;
 
 import diamond.core.apptype;
 
@@ -28,7 +28,7 @@ static if (isWebApi)
     }
 
     import diamond.controllers.status;
-    
+
     auto status = controllerAction(client).handle();
 
     if (status == Status.notFound)

--- a/app/api.d
+++ b/app/api.d
@@ -18,7 +18,7 @@ static if (isWebApi)
   */
   void handleWebApi(HttpClient client)
   {
-    import diamond.init.web : getControllerAction;
+    import diamond.app.web : getControllerAction;
 
     auto controllerAction = getControllerAction(client.route.name);
 

--- a/app/diamondapp.d
+++ b/app/diamondapp.d
@@ -7,7 +7,7 @@ module diamondapp;
 
 import diamond.core : isWeb;
 
-public import diamond.init.web;
+public import diamond.app.web;
 
 // static if (isWeb)
 // {

--- a/app/files.d
+++ b/app/files.d
@@ -3,7 +3,7 @@
 * License: MIT (https://github.com/DiamondMVC/Diamond/blob/master/LICENSE)
 * Author: Jacob Jensen (bausshf)
 */
-module diamond.init.files;
+module diamond.app.files;
 
 import diamond.core.apptype;
 

--- a/app/files.d
+++ b/app/files.d
@@ -19,7 +19,7 @@ static if (isWeb)
   *   client =     The client.
   *   staticFile =  The static file handler.
   */
-  package(diamond.init) void handleStaticFiles
+  package(diamond.app) void handleStaticFiles
   (
     HttpClient client,
     HTTPServerRequestDelegateS staticFile

--- a/app/server.d
+++ b/app/server.d
@@ -3,7 +3,7 @@
 * License: MIT (https://github.com/DiamondMVC/Diamond/blob/master/LICENSE)
 * Author: Jacob Jensen (bausshf)
 */
-module diamond.init.server;
+module diamond.app.server;
 
 import diamond.core.apptype;
 

--- a/app/server.d
+++ b/app/server.d
@@ -52,7 +52,7 @@ static if (isWebServer)
       }
     }
 
-    import diamond.init.web : getView;
+    import diamond.app.web : getView;
 
     import diamond.views.view : View;
 

--- a/app/web.d
+++ b/app/web.d
@@ -3,7 +3,7 @@
 * License: MIT (https://github.com/DiamondMVC/Diamond/blob/master/LICENSE)
 * Author: Jacob Jensen (bausshf)
 */
-module diamond.init.web;
+module diamond.app.web;
 
 import diamond.core.apptype;
 

--- a/app/web.d
+++ b/app/web.d
@@ -481,7 +481,7 @@ static if (isWeb)
 
       if (staticFile)
       {
-        import diamond.init.files;
+        import diamond.app.files;
         handleStaticFiles(client, staticFile);
 
         static if (loggingEnabled)
@@ -496,7 +496,7 @@ static if (isWeb)
 
     static if (isWebServer)
     {
-      import diamond.init.server;
+      import diamond.app.server;
       auto foundPage = client.forceApi ? false : handleWebServer(client);
     }
     else
@@ -508,7 +508,7 @@ static if (isWeb)
     {
       if (!foundPage)
       {
-        import diamond.init.api;
+        import diamond.app.api;
         handleWebApi(client);
       }
     }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
 	"copyright": "Copyright © 2016-2018 Diamond MVC",
 	"targetType": "sourceLibrary",
 	"sourcePaths": [
-		"authentication", "controllers", "core",
-		"data", "database", "errors",
-		"extensions", "http", "init",
+		"app", "authentication", "controllers",
+		"core", "data", "database",
+		"errors","extensions", "http",
 		"io", "mail", "markdown",
 		"security", "seo", "tasks",
 		"templates", "unittesting", "views",


### PR DESCRIPTION
"app" is a more suitable name for the modules currently located in "init" because it represents the different application handlers for Diamond and not only initialization as previously described.