### PR TITLE
Global view state

### DIFF
--- a/app/web.d
+++ b/app/web.d
@@ -185,6 +185,8 @@ static if (isWeb)
 
   static if (isWebServer)
   {
+    mixin(generateGlobalView());
+    
     mixin GenerateViews;
 
     static foreach (viewResult; generateViewsResult)

--- a/core/webinitialization.d
+++ b/core/webinitialization.d
@@ -10,6 +10,25 @@ import diamond.core.apptype;
 static if (isWebApi)
 {
   /**
+  * Generates the global view data.
+  * Returns:
+  *   A string containing all global view data such as imports etc.
+  */
+  string generateGlobalView()
+  {
+    string content;
+
+    import diamond.core.io : handleCTFEFile;
+
+    mixin handleCTFEFile!("globalview.d", q{
+      content = __fileResult;
+    });
+    handle();
+
+    return content ? content : "";
+  }
+
+  /**
   * Generates the controller data.
   * Returns:
   *   An array with the names of the controllers to handle.


### PR DESCRIPTION
Allows for functions, imports and other global code to be shared between views without explicit imports to a shared module/package.