### PR TITLE
Interpret view name as the file name

### DIFF
--- a/core/webinitialization.d
+++ b/core/webinitialization.d
@@ -86,7 +86,7 @@ static if (isWebServer)
             continue;
           }
 
-          auto data = line.split("|");
+          auto data = line.split(".");
 
           if (data.length != 2)
           {
@@ -101,7 +101,7 @@ static if (isWebServer)
           }
           else
           {
-            viewDataString ~= "  viewData[\"" ~ data[0].strip() ~ "\"] = import(\"" ~ data[1].strip() ~ "\");";
+            viewDataString ~= "  viewData[\"" ~ data[0].strip() ~ "\"] = import(\"" ~ (data[0].strip() ~ "." ~ data[1].strip()) ~ "\");";
           }
         }
       }


### PR DESCRIPTION
This is different from how it works today.

Now you have to declare a name and a file name, but in the future you just need to give the filename and the filename itself will be the name of the view. This makes it easy to write scripts that generate the "views.config" file.